### PR TITLE
compatibility

### DIFF
--- a/ಠ_ಠ.js
+++ b/ಠ_ಠ.js
@@ -5,4 +5,4 @@
   } else {
     self['ಠ_ಠ'] = function () {}
   }
-}(typeof window !== 'undifined'? window : typeof global !== 'undefined' ? global : self));
+}(typeof window !== 'undefined'? window : typeof global !== 'undefined' ? global : self));


### PR DESCRIPTION
should work in node.js, web workers (which do have console.log) and old shitty versions of IE where console.log isn't a real function.
