### PR TITLE
Remove the unobvious `window.ಠ_ಠ` call

### DIFF
--- a/ಠ_ಠ.js
+++ b/ಠ_ಠ.js
@@ -1,4 +1,6 @@
 (function () {
   "use strict";
-  window['ಠ_ಠ'] = function () {typeof console !== "undefined"? console.log.apply(console, arguments):null};
+  var log = window.console.log;
+  window['ಠ_ಠ'] = function () {typeof console !== "undefined"? log.apply(console, arguments):null};
+  window.console.log = undefined;
 }());


### PR DESCRIPTION
Having such a great way to inspect variables, do we still need the clumsy duplicate method?
